### PR TITLE
Fix macOS builds

### DIFF
--- a/include/ml/mlp_net.hpp
+++ b/include/ml/mlp_net.hpp
@@ -224,7 +224,7 @@ class SecondaryMLP {
         for (uint64_t i = 0; i < layer_units.size() - 1; ++i) {
             Matrix y = wt_mtx[i].mult(prev);
             y = y + bias_vectors[i];
-            y = y.apply_function(sigmoid_activ);
+            y = y.apply_function(&SecondaryMLP::sigmoid_activ);
             activations[i + 1] = y;
             prev = y;
         }
@@ -250,8 +250,8 @@ class SecondaryMLP {
             // calculate errors for previous layer
             auto wt = wt_mtx[i].T();
             auto prior_errs = wt.mult(err);
-            auto outputs_d =
-                activations[i + 1].apply_function(sigmoid_deriv);
+            auto outputs_d = activations[i + 1].apply_function(
+                &SecondaryMLP::sigmoid_deriv);
             auto gradients = err.hadamard(outputs_d);
             gradients = gradients.scalar_mult(lr);
             auto trans_a = activations[i].T();

--- a/include/nt/primes.hpp
+++ b/include/nt/primes.hpp
@@ -62,14 +62,13 @@ class Primality {
     /**
      * @brief Algorithm determining liklihood a number is prime
      *
-     * @param[in] d : target number (int64_t)
-     * @param[in] n : target - 1 (int64_t)
+     * @param[in] n : target number (int64_t)
      *
      * @pre miller_rabin_prime()
      *
      * @return true/false (bool)
      */
-    bool compute_miller_rabin(int64_t d, int64_t n);
+    bool compute_miller_rabin(int64_t n);
 
     /**
      * @brief Modified primes algorithm

--- a/modules/nt/primes.cpp
+++ b/modules/nt/primes.cpp
@@ -81,7 +81,19 @@ bool mtpk::Primality::is_prime(int64_t n) {
 /*
  * determining if a given number is likely to be prime
  */
-bool mtpk::Primality::compute_miller_rabin(int64_t d, int64_t n) {
+bool mtpk::Primality::compute_miller_rabin(int64_t n) {
+    // these are corner cases
+    if (n <= 1 || n == 4)
+        return false;
+    if (n <= 3)
+        return true;
+
+    // d will represent an odd number
+    int64_t d = n - 1;
+    while (d % 2 == 0) {
+        d /= 2;
+    }
+
     // Pick a random number in [2..n-2] Corner cases make sure that n
     // > 4
     int64_t a = 2 + rand() % (n - 4);
@@ -116,22 +128,11 @@ bool mtpk::Primality::miller_rabin_prime(int64_t n, int64_t iters) {
      * this method will return true if n is prime, iters will
      * determine accuracy
      */
-    // these are corner cases
-    if (n <= 1 || n == 4)
-        return false;
-    if (n <= 3)
-        return true;
-
-    // odd will represent an odd number
-    int64_t odd = n - 1;
-    while (odd % 2 == 0) {
-        odd /= 2;
-    }
 
     // iterate given the iters paramater
     for (int64_t i = 0; i < iters; i++) {
         // compute using the Miller-Rabin method
-        if (!compute_miller_rabin(odd, n)) {
+        if (!compute_miller_rabin(n)) {
             return false;
         }
     }

--- a/tests/nt/t_primes.cpp
+++ b/tests/nt/t_primes.cpp
@@ -112,13 +112,13 @@ TEST(prime_test, mod_pow) {
  * computes primes using the Miller-Rabin method
  */
 TEST(prime_test, compute_miller_rabin) {
-    EXPECT_EQ(true, p.compute_miller_rabin(7, 5));
-    EXPECT_EQ(true, p.compute_miller_rabin(7, 1));
-    EXPECT_EQ(true, p.compute_miller_rabin(1049, 5));
-    EXPECT_EQ(true, p.compute_miller_rabin(2999, 5));
-    EXPECT_EQ(true, p.compute_miller_rabin(4, 2));
-    EXPECT_EQ(true, p.compute_miller_rabin(200392, 5));
-    EXPECT_EQ(true, p.compute_miller_rabin(90, 5));
+    EXPECT_EQ(true, p.compute_miller_rabin(5));
+    EXPECT_EQ(false, p.compute_miller_rabin(1));
+    EXPECT_EQ(true, p.compute_miller_rabin(5));
+    EXPECT_EQ(true, p.compute_miller_rabin(5));
+    EXPECT_EQ(true, p.compute_miller_rabin(2));
+    EXPECT_EQ(true, p.compute_miller_rabin(5));
+    EXPECT_EQ(true, p.compute_miller_rabin(5));
 }
 
 TEST(prime_test, miller_rabin_prime) {


### PR DESCRIPTION
This pull request fixes hanging test cases on macOS during build time.

## Issue

`compute_miller_rabin()` expects two arguments: `d` and `n`, where `d` is an odd number and `n` is the target number to be checked. `d` is generated by `miller_rabin_prime()` and the boundaries for `n` are handled in `miller_rabin_prime()`. These boundaries are not handled by `compute_miller_rabin()` as it expects the input `n` to be greater than 4.

## Changes Made

- [include/nt/primes.hpp](include/nt/primes.hpp): change the signature of `compute_miller_rabin()` to accept only the target number
- [modules/nt/primes.cpp](modules/nt/primes.cpp): move the boundary check and `d` generation to `compute_miller_rabin()`
- [tests/nt/t_primes.cpp](tests/nt/t_primes.cpp): pass only one argument to `compute_miller_rabin()` and fix the expected outcome for `compute_miller_rabin(1)` to false, since 1 is not a prime number

One auxiliary change was necessary to successfully build openMTPK.

- [include/ml/mlp_net.hpp](include/ml/mlp_net.hpp): `sigmoid_activ` and `sigmoid_deriv` were incorrectly passed as the compiler recognized them as static functions and not member functions

## Testing Done

The changes are tested on macOS 13.3 running on M2.

Fixes #27 